### PR TITLE
fix: Market Activity report particulary parsed

### DIFF
--- a/nsedt/reports.py
+++ b/nsedt/reports.py
@@ -9,6 +9,9 @@ from nsedt.resources.constants import (
     REPORT_URL, MARKET_ACTIVITY_REPORT,
     BHAV_COPY_REPORT, SEC_BHAV_COPY_REPORT, NSCCL_REPORTS, NSCCL_VOLT)
 
+import pandas as pd
+from io import BytesIO
+
 log = logging.getLogger("root")
 
 # tbd
@@ -23,8 +26,8 @@ def get_market_activity_report(date: str):
     Args:\n
         date (str): date for which to download market activity report\n
     Returns:
-        string: string content of the file as right now its not possible 
-        to format the content to json or pandas df
+        df = Returns dataframe for  market activity report for sectors
+        for the given date
     Expects:
         date to be in format of  "dd-mm-yyyy" eg: 30-04-2024
         all other cases will be invalidated
@@ -35,8 +38,11 @@ def get_market_activity_report(date: str):
 
     cookies = get_cookies()
     url = f"{REPORT_URL}{MARKET_ACTIVITY_REPORT}{date}.csv"
-    return fetch_csv(url, cookies, response_type="raw")
-
+    response = fetch_csv(url, cookies, response_type="raw")
+    df = pd.read_csv(BytesIO(response), skiprows=8)
+    df.drop(columns=['Unnamed: 0'], inplace=True)
+    df = df[:77]
+    return df
 
 def get_volatility_report(date: str, response_type: str="panda_df"):
     """

--- a/nsedt/reports.py
+++ b/nsedt/reports.py
@@ -4,8 +4,8 @@ function to download reports
 
 import logging
 
-import pandas as pd
 from io import BytesIO
+import pandas as pd
 
 from nsedt.utils import get_cookies, fetch_csv, format_date, fetch_zip
 from nsedt.resources.constants import (

--- a/nsedt/reports.py
+++ b/nsedt/reports.py
@@ -4,13 +4,14 @@ function to download reports
 
 import logging
 
+import pandas as pd
+from io import BytesIO
+
 from nsedt.utils import get_cookies, fetch_csv, format_date, fetch_zip
 from nsedt.resources.constants import (
     REPORT_URL, MARKET_ACTIVITY_REPORT,
     BHAV_COPY_REPORT, SEC_BHAV_COPY_REPORT, NSCCL_REPORTS, NSCCL_VOLT)
 
-import pandas as pd
-from io import BytesIO
 
 log = logging.getLogger("root")
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -17,7 +17,7 @@ def test_get_market_activity_report():
     Test get market activity report for a given date
     """
     data = get_market_activity_report(date=REPORT_DATE)
-    assert isinstance(data, bytes)
+    assert isinstance(data, pd.DataFrame)
 
 
 def test_get_bhav_copy_zip():


### PR DESCRIPTION
Previously the data from function get_market_activity_report in reports.py was
     - Unorganized
     - Bytes format
     - Contained irrelevant headers and metadata
     - Not Convertible to dataframe
     
Now this function returns 
     - Dataframe with only relevant data